### PR TITLE
Add hash to the circuit public input

### DIFF
--- a/circuits/the_word.circom
+++ b/circuits/the_word.circom
@@ -21,4 +21,4 @@ template the_word(num_felts) {
     hash <== hasher.out;
 }
 
-component main { public [username] } = the_word(6);
+component main { public [hash, username] } = the_word(6);


### PR DESCRIPTION
The hash should be in the public input so that the verifier can check if the user knows the secret.

Otherwise, the user can input an arbitrary secret phrase and arbitrary hash, and the verifier has no way to detect it.